### PR TITLE
Fix: remove sensitive data from logs

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -21,6 +21,7 @@
     "@nestjs/jwt": "^10.0.2",
     "@nestjs/platform-fastify": "^9.3.9",
     "@plurk-search/common": "workspace:*",
+    "maskdata": "^1.2.6",
     "plurk2": "^0.5.2",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.5.5"

--- a/api/src/auth/auth.controller.ts
+++ b/api/src/auth/auth.controller.ts
@@ -1,6 +1,7 @@
 import { Body, Controller, Get, HttpCode, HttpStatus, Logger, Post } from '@nestjs/common';
 import type { AuthResultsDto } from '@plurk-search/common/dto/AuthResults';
 import { AuthToken } from '~api/common/authToken.decorator';
+import { maskSecrets } from '~api/common/maskSecretsHelper';
 import { AuthService } from './auth.service'; // eslint-disable-line @typescript-eslint/consistent-type-imports -- Nestjs dependency injection
 
 @Controller('/auth')
@@ -25,6 +26,7 @@ export class AuthController {
   }
 
   private logRequest(endpoint: string, params: any) {
-    this.logger.log(`Received Request: ${endpoint}; params: ${JSON.stringify(params)}`);
+    const guardedParams = maskSecrets(params);
+    this.logger.log(`Received Request: ${endpoint}; params: ${JSON.stringify(guardedParams)}`);
   }
 }

--- a/api/src/auth/auth.service.ts
+++ b/api/src/auth/auth.service.ts
@@ -53,7 +53,6 @@ export class AuthService {
 
   private verifyToken(token: string) {
     try {
-      this.logger.log(`verifying token: ${token}`);
       this.jwtService.verify(token);
     } catch (err: any) {
       this.logger.error('token verification failed', err.stack, err.message);

--- a/api/src/common/maskSecretsHelper.spec.ts
+++ b/api/src/common/maskSecretsHelper.spec.ts
@@ -1,0 +1,36 @@
+import maskSecrets from '~api/common/maskSecretsHelper';
+import { mockApiResponse } from '~api/gateway/constants';
+
+function expectMasked(inputStr: string): void {
+  expect(inputStr).toMatch(/\*+/);
+  expect(inputStr.length).toBeLessThanOrEqual(5);
+}
+
+describe('Helper - maskSecretsHelper', () => {
+  it('should mask sensitive fields in plurk response', () => {
+    // when
+    const result = maskSecrets(mockApiResponse);
+
+    // then
+    result.plurks.forEach(plurk => {
+      expectMasked(plurk.content);
+      expectMasked(plurk.content_raw);
+    });
+    Object.values(result.plurk_users).forEach(user => {
+      expectMasked(user.nick_name);
+      expectMasked(user.display_name);
+    });
+  });
+
+  it('should mask auth-related fields', () => {
+    // when
+    const result = maskSecrets({
+      token: 'this is the token',
+      secret: 123456,
+    });
+
+    // then
+    expectMasked(result.token);
+    expectMasked(result.secret.toString());
+  });
+});

--- a/api/src/common/maskSecretsHelper.ts
+++ b/api/src/common/maskSecretsHelper.ts
@@ -1,0 +1,25 @@
+import { maskJSON2 } from 'maskdata';
+
+export function maskSecrets<T extends Record<string, unknown>>(obj: T): T {
+  const fileredObj = maskJSON2(obj, {
+    passwordMaskOptions: {
+      maskWith: '*',
+      maxMaskedCharacters: 5,
+    },
+    passwordFields: [
+      // auth
+      'token',
+      'secret',
+      // plurk
+      'plurks[*].content',
+      'plurks[*].content_raw',
+      // user info - masking all fields for now
+      'plurk_users.*',
+      // 'plurk_users.*.nick_name',
+      // 'plurk_users.*.display_name',
+    ],
+  });
+  return fileredObj;
+};
+
+export default maskSecrets;

--- a/api/src/gateway/plurk-api.service.ts
+++ b/api/src/gateway/plurk-api.service.ts
@@ -3,6 +3,7 @@ import { ConfigService } from '@nestjs/config'; // eslint-disable-line @typescri
 import type { PlurkDto } from '@plurk-search/common/dto/Plurk';
 import { FilterType } from '@plurk-search/common/enum/FilterType';
 import { PlurkClient } from 'plurk2';
+import maskSecrets from '~api/common/maskSecretsHelper';
 import { isNullish } from '~api/common/util';
 import { AuthObject } from '~api/dataobject/AuthObject';
 import { PlurksSerializer } from './plurks.serializer'; // eslint-disable-line @typescript-eslint/consistent-type-imports -- Nestjs dependency injection
@@ -30,7 +31,7 @@ export class PlurkApiService {
       this.logger.log('Requesting request token');
       this.resetAuth();
       const { token, tokenSecret, authPage } = await this.plurkApi.getRequestToken();
-      this.logger.log(`Token received: ${token}`);
+      this.logger.log(`Token received with length: ${token.length}`);
       return { token, secret: tokenSecret, authPage };
     } catch (err: any) {
       this.logger.error('Failed to get reqeust token', err.stack, err.message);
@@ -45,7 +46,7 @@ export class PlurkApiService {
     try {
       this.logger.log('Requesting access token');
       const { token, tokenSecret } = await this.plurkApi.getAccessToken(code);
-      this.logger.log(`Token received: ${token}`);
+      this.logger.log(`Token received. Length = ${token.length}`);
       return new AuthObject({ token, secret: tokenSecret });
     } catch (err: any) {
       this.logger.error('Failed to get access token.', err.stack, err.message);
@@ -105,6 +106,7 @@ export class PlurkApiService {
   }
 
   private logResponse(response: any) {
-    this.logger.log(`Received Plurk API response: ${JSON.stringify(response)}`);
+    const guardedResponse = maskSecrets(response);
+    this.logger.log(`Received Plurk API response: ${JSON.stringify(guardedResponse)}`);
   }
 }

--- a/api/src/search/search.controller.ts
+++ b/api/src/search/search.controller.ts
@@ -2,6 +2,7 @@ import { Controller, DefaultValuePipe, Get, Logger, Query } from '@nestjs/common
 import type { SearchResultsDto } from '@plurk-search/common/dto/SearchResults';
 import { FilterType } from '@plurk-search/common/enum/FilterType';
 import { AuthToken } from '~api/common/authToken.decorator';
+import maskSecrets from '~api/common/maskSecretsHelper';
 import { ParseEnumPipe } from '~api/pipe/parse-enum.pipe';
 import { SearchService } from './search.service'; // eslint-disable-line @typescript-eslint/consistent-type-imports -- Nestjs dependency injection
 
@@ -23,6 +24,7 @@ export class SearchController {
   }
 
   private logRequest(endpoint: string, params: any) {
-    this.logger.log(`Received Request: ${endpoint}; params: ${JSON.stringify(params)}`);
+    const guardedParams = maskSecrets(params);
+    this.logger.log(`Received Request: ${endpoint}; params: ${JSON.stringify(guardedParams)}`);
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7593,6 +7593,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"maskdata@npm:^1.2.6":
+  version: 1.2.6
+  resolution: "maskdata@npm:1.2.6"
+  dependencies:
+    lodash: ^4.17.21
+  checksum: 59d1d8a27c81ea602749417693017e736c067099b24570d6b28d39f110098e04ee3415c97b10b38e9396673c4eeca34b011e0f95aa284fe96233f8cd56ae2ddc
+  languageName: node
+  linkType: hard
+
 "media-typer@npm:0.3.0":
   version: 0.3.0
   resolution: "media-typer@npm:0.3.0"
@@ -8603,6 +8612,7 @@ __metadata:
     eslint-plugin-import: ^2.29.0
     eslint-plugin-n: ^16.3.1
     eslint-plugin-promise: ^6.1.1
+    maskdata: ^1.2.6
     node-mocks-http: ^1.12.1
     plurk2: ^0.5.2
     reflect-metadata: ^0.1.13


### PR DESCRIPTION
## Configuration change
1. added a new package `maskdata`

## Feature/fix description
User information and the plurk contents shouldn't be logged / saved / exposed across the project.
This PR removes sensitive fields from the logs.
